### PR TITLE
feat: erase source_image 필드 추가

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,15 @@ def test_rgba_mask() -> str:
 
 
 @pytest.fixture
+def test_source_image() -> str:
+    """100x100 RGB 소스 이미지 (base64)"""
+    img = Image.new("RGB", (100, 100), color="blue")
+    buffer = BytesIO()
+    img.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+@pytest.fixture
 def setup_translate(
     fake_redis: fakeredis.FakeRedis,
     temp_upload_dir: Path,


### PR DESCRIPTION
## 요약

- `EraseRequest`에 `source_image` 필드 추가 (optional)
- source_image가 있으면 디스크 파일 대신 전달받은 이미지를 사용해 inpainting 수행
- RGBA → RGB 변환 처리
- 기존 동작 하위 호환 (source_image 없으면 기존대로 파일 로드)

closes #20