### PR TITLE
chore: AWS EC2 배포를 위한 Docker 설정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.venv/
+__pycache__/
+*.pyc
+.git/
+.env
+.ruff_cache/
+debug_output/
+tests/
+scripts/
+uploads/
+.pytest_cache/
+.pre-commit-config.yaml

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 
 # App
+# 프로덕션: EC2 퍼블릭 IP 또는 도메인 (예: http://ec2-xx-xx-xx-xx.compute.amazonaws.com:8000)
 BASE_URL=http://localhost:8000
+# 프로덕션: Vercel 도메인 추가 (예: ["https://toonslate.vercel.app"])
 CORS_ORIGINS=["http://localhost:5173"]
 
 # Celery

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim AS base
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /bin/
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --group ai --no-install-project
+
+COPY src/ src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  web:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    env_file: .env
+    environment:
+      - REDIS_HOST=redis
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  worker:
+    build: .
+    command: celery -A src.infra.celery_app:celery_app worker --loglevel=info --concurrency=2
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      - REDIS_HOST=redis
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      redis:
+        condition: service_healthy
+
+volumes:
+  redis-data:
+  uploads:

--- a/src/infra/celery_app.py
+++ b/src/infra/celery_app.py
@@ -19,4 +19,5 @@ celery_app.conf.update(
     enable_utc=True,
     result_expires=TTL.CELERY_RESULT,
     imports=["src.infra.workers.translate_job"],
+    worker_prefetch_multiplier=1,
 )


### PR DESCRIPTION
## 변경 내용
- Dockerfile (Python 3.11 + uv 0.9.26 고정)
- docker-compose.yml (web + worker + redis)
  - Redis: AOF 영속성, healthcheck, 외부 포트 비노출
  - Worker: `--concurrency=2` 명시
  - 전체: `restart: unless-stopped`
- .dockerignore
- `/health` (liveness) + `/health/ready` (readiness) 분리
- Celery `worker_prefetch_multiplier=1`
- `.env.example` 프로덕션 설정 안내

## 후속 작업
- [ ] 프록시 IP 처리 (`X-Forwarded-For` 신뢰 체인) — nginx/ALB 도입 시
- [ ] uploads 디스크 정리 크론/배치
- [ ] CI/CD 파이프라인 (push → 자동 배포)

closes #27